### PR TITLE
remove numba.cuda.synchronize()

### DIFF
--- a/lcode.py
+++ b/lcode.py
@@ -180,7 +180,6 @@ def calculate_Ez(config, jx, jy):
     #    hidden inside dirichlet_matrix.
     Ez_inner = dst2d(f)
     Ez = cp.pad(Ez_inner, 1, 'constant', constant_values=0)
-    numba.cuda.synchronize()
     return Ez
 
 
@@ -357,7 +356,6 @@ def calculate_Bz(config, jx, jy):
     #    and we take all scaling matters into account with a single factor
     #    hidden inside neumann_matrix.
     Bz = dct2d(f)
-    numba.cuda.synchronize()
 
     Bz -= Bz.mean()  # Integral over Bz must be 0.
 
@@ -387,7 +385,6 @@ def move_estimate_wo_fields(config,
 
     x_offt, y_offt = x - x_init, y - y_init
 
-    numba.cuda.synchronize()
     return x_offt, y_offt
 
 
@@ -685,7 +682,6 @@ def deposit(config, ro_initial, x_offt, y_offt, m, q, px, py, pz, virt_params):
                         ro, jx, jy, jz)
     # Also add the background ion charge density.
     ro += ro_initial  # Do it last to preserve more float precision
-    numba.cuda.synchronize()
     return ro, jx, jy, jz
 
 
@@ -819,7 +815,6 @@ def move_smart(config,
                            Ex_avg, Ey_avg, Ez_avg, Bx_avg, By_avg, Bz_avg,
                            x_offt_new.ravel(), y_offt_new.ravel(),
                            px_new.ravel(), py_new.ravel(), pz_new.ravel())
-    numba.cuda.synchronize()
     return x_offt_new, y_offt_new, px_new, py_new, pz_new
 
 


### PR DESCRIPTION
Remove numba.cuda.synchronize(). You can add it back later more thoroughly when you'll need to profile the code next time.